### PR TITLE
Add tags to testing playbook

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,5 +6,7 @@ Vagrant.configure(2) do |config|
   config.vm.synced_folder "./", "/home/vagrant/FingerprintSecureDrop/", disabled: false
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "playbook.yml"
+    # Hack to support CLI options such as `--tags` and `--skip-tags`.
+    ansible.raw_arguments = Shellwords.shellsplit(ENV['ANSIBLE_ARGS']) if ENV['ANSIBLE_ARGS']
   end
 end

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,18 +1,21 @@
 ---
 - name: Update the Ubuntu image and install the packages both scripts need.
   hosts: all
-  roles: 
+  roles:
     - role: common
+      tags: common
 
 - name: Install and configure dependencies for Tor.
   hosts: all
   roles:
     - role: crawler
+      tags: crawler
 
 # Todo: currently sorter depends on crawler role for Tor. The sorter role should
 # see if the custom tor binary has been compiled, and if not just install tor
 # from the tor deb repos to save time.
 - name: Install the Apt and Python dependencies of the sorter script.
   hosts: all
-  roles: 
-    - { role: sorter, tag: sorter }
+  roles:
+    - role: sorter
+      tags: sorter


### PR DESCRIPTION
Minor changes to the Vagrantfile and testing playbook, to support ad-hoc isolation of roles via tags. Potential invocations now include:

```
ANSIBLE_ARGS="--tags crawler" vagrant provision 
```

If you find yourself reusing an env var prefix, export that env var during development so a simple `vagrant provision` targets only the role you're working on.

Closes #11.
