### PR TITLE
Use default vars for database role

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -22,5 +22,3 @@
   roles:
     - role: database
       tags: database
-  vars_files:
-    - database-vars.yml

--- a/roles/database/defaults/main.yml
+++ b/roles/database/defaults/main.yml
@@ -1,17 +1,17 @@
 ---
-postgresql_apt_packages:
+fpsd_database_apt_packages:
   - postgresql
   - libpq-dev
   - python-psycopg2
 
-psql_env:
+fpsd_database_psql_env:
   PGHOST: "{{ PGHOST }}"
   PGPORT: "{{ PGPORT }}"
   PGDATABASE: "{{ PGDATABASE }}"
   PGUSER: "{{ PGUSER }}"
   PGPASSFILE: "{{ ansible_env.HOME }}/.pgpass"
 
-raw_schema_tables:
+fpsd_database_raw_schema_tables:
   - create_table_crawls.sql
   - create_table_hs_history.sql
   - create_table_frontpage_examples.sql

--- a/roles/database/defaults/main.yml
+++ b/roles/database/defaults/main.yml
@@ -21,6 +21,10 @@ fpsd_database_psql_env:
   PGDATABASE: fpsd
   PGPASSFILE: "{{ ansible_env.HOME }}/.pgpass"
 
+# If left undefined, a randomly generated password will be created and written
+# to /tmp on the Ansible controller.
+fpsd_database_password: ''
+
 fpsd_database_raw_schema_tables:
   - create_table_crawls.sql
   - create_table_hs_history.sql

--- a/roles/database/defaults/main.yml
+++ b/roles/database/defaults/main.yml
@@ -16,3 +16,11 @@ fpsd_database_raw_schema_tables:
   - create_table_hs_history.sql
   - create_table_frontpage_examples.sql
   - create_table_frontpage_traces.sql
+
+# Defaults to true. Set to false if you want to use a remote database. If you
+# wish not to use the database at all, set the environment variable
+# `ANSIBLE_ARGS="--skip-tags=database"`. If set to false you must fill out all
+# vars in the field below so Ansible can still set the appropriate environment
+# variables and create the PGPASSFILE for it just works™ access to your remote
+# database.
+fpsd_database_initialize_local_db: true

--- a/roles/database/defaults/main.yml
+++ b/roles/database/defaults/main.yml
@@ -4,11 +4,21 @@ fpsd_database_apt_packages:
   - libpq-dev
   - python-psycopg2
 
+# All of these vars except password will be set as environment variables in
+# `/etc/bash.bashrc`. If password is not set, then Ansible will generate one for
+# you at provision-time. The password will not be set as an environment
+# variable, but is instead saved to a PGPASSFILE, `~{{ ssh_username }}/.pgpass`,
+# along with the corresponding information from the other vars according to the
+# PGPASSFILE spec.
+#
+# Note: the database role will not overwrite an existing PGPASSFILE, so in order
+# to do so, you'll have to first remove it then re-run the role:
+# `ANSIBLE_ARGS="--tags=database vagrant provision"`.
 fpsd_database_psql_env:
-  PGHOST: "{{ PGHOST }}"
-  PGPORT: "{{ PGPORT }}"
-  PGDATABASE: "{{ PGDATABASE }}"
-  PGUSER: "{{ PGUSER }}"
+  PGHOST: localhost
+  PGUSER: fp_user
+  PGPORT: "5432"
+  PGDATABASE: fpsd
   PGPASSFILE: "{{ ansible_env.HOME }}/.pgpass"
 
 fpsd_database_raw_schema_tables:

--- a/roles/database/defaults/main.yml
+++ b/roles/database/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+# Username to configure postgres access for.
+fpsd_database_username: "{{ ansible_user|default(lookup('env', 'USER')) }}"
+
 fpsd_database_apt_packages:
   - postgresql
   - libpq-dev

--- a/roles/database/tasks/initialize-fpsd-db.yml
+++ b/roles/database/tasks/initialize-fpsd-db.yml
@@ -9,7 +9,7 @@
     postgresql_user:
       name: fp_user
       password: "{{ password }}"
-    when: "'{{ psql_env.PGHOST }}' not in postgres_roles.stdout and password"
+    when: "'{{ fpsd_database_psql_env.PGHOST }}' not in postgres_roles.stdout and password"
 
   - name: Create PostgreSQL user with a randomnly-generated password.
     postgresql_user:
@@ -17,12 +17,12 @@
       # We don't include punctuation to avoid needing to escape ':' and '\' in the
       # PGPASSFILE
       password: "{{ lookup('password', '/tmp/passwordfile chars=ascii_letters,digits') }}"
-    when: "'{{ psql_env.PGHOST }}' not in postgres_roles.stdout and not password"
+    when: "'{{ fpsd_database_psql_env.PGHOST }}' not in postgres_roles.stdout and not password"
 
   - name: Create the database.
     postgresql_db:
-      name: "{{ psql_env.PGDATABASE }}"
-      owner: "{{ psql_env.PGUSER }}"
+      name: "{{ fpsd_database_psql_env.PGDATABASE }}"
+      owner: "{{ fpsd_database_psql_env.PGUSER }}"
       encoding: UTF-8 
       lc_collate: en_US.UTF-8
       lc_ctype: en_US.UTF-8

--- a/roles/database/tasks/initialize-fpsd-db.yml
+++ b/roles/database/tasks/initialize-fpsd-db.yml
@@ -24,7 +24,7 @@
     postgresql_db:
       name: "{{ fpsd_database_psql_env.PGDATABASE }}"
       owner: "{{ fpsd_database_psql_env.PGUSER }}"
-      encoding: UTF-8 
+      encoding: UTF-8
       lc_collate: en_US.UTF-8
       lc_ctype: en_US.UTF-8
       template: template0

--- a/roles/database/tasks/initialize-fpsd-db.yml
+++ b/roles/database/tasks/initialize-fpsd-db.yml
@@ -3,6 +3,7 @@
   - name: Record present roles.
     command: psql -c "SELECT rolname FROM pg_roles;"
     register: postgres_roles
+    always_run: true
     changed_when: false
 
   - name: Create PostgreSQL user with user-defined password.

--- a/roles/database/tasks/initialize-fpsd-db.yml
+++ b/roles/database/tasks/initialize-fpsd-db.yml
@@ -8,13 +8,13 @@
 
   - name: Create PostgreSQL user with user-defined password.
     postgresql_user:
-      name: fp_user
+      name: "{{ fpsd_database_psql_env.PGUSER }}"
       password: "{{ fpsd_database_password }}"
     when: "'{{ fpsd_database_psql_env.PGHOST }}' not in postgres_roles.stdout and fpsd_database_password"
 
   - name: Create PostgreSQL user with a randomnly-generated password.
     postgresql_user:
-      name: fp_user
+      name: "{{ fpsd_database_psql_env.PGUSER }}"
       # We don't include punctuation to avoid needing to escape ':' and '\' in the
       # PGPASSFILE
       password: "{{ lookup('password', '/tmp/passwordfile chars=ascii_letters,digits') }}"

--- a/roles/database/tasks/initialize-fpsd-db.yml
+++ b/roles/database/tasks/initialize-fpsd-db.yml
@@ -8,8 +8,8 @@
   - name: Create PostgreSQL user with user-defined password.
     postgresql_user:
       name: fp_user
-      password: "{{ password }}"
-    when: "'{{ fpsd_database_psql_env.PGHOST }}' not in postgres_roles.stdout and password"
+      password: "{{ fpsd_database_password }}"
+    when: "'{{ fpsd_database_psql_env.PGHOST }}' not in postgres_roles.stdout and fpsd_database_password"
 
   - name: Create PostgreSQL user with a randomnly-generated password.
     postgresql_user:
@@ -17,7 +17,7 @@
       # We don't include punctuation to avoid needing to escape ':' and '\' in the
       # PGPASSFILE
       password: "{{ lookup('password', '/tmp/passwordfile chars=ascii_letters,digits') }}"
-    when: "'{{ fpsd_database_psql_env.PGHOST }}' not in postgres_roles.stdout and not password"
+    when: "'{{ fpsd_database_psql_env.PGHOST }}' not in postgres_roles.stdout and not fpsd_database_password"
 
   - name: Create the database.
     postgresql_db:

--- a/roles/database/tasks/initialize-raw-schema.yml
+++ b/roles/database/tasks/initialize-raw-schema.yml
@@ -3,6 +3,7 @@
   - name: List all schemas in the fpsd database.
     command: psql -c '\dn' fpsd
     register: schemas
+    always_run: true
     changed_when: false
 
   - name: Create the raw schema.
@@ -12,6 +13,7 @@
   - name: List all tables in the raw schema.
     command: psql -c '\dt raw.*'
     register: tables
+    always_run: true
     changed_when: false
 
   - name: "Create the tables: crawls, hs_history, frontpage_examples, & frontpage_traces."

--- a/roles/database/tasks/initialize-raw-schema.yml
+++ b/roles/database/tasks/initialize-raw-schema.yml
@@ -17,8 +17,8 @@
   - name: "Create the tables: crawls, hs_history, frontpage_examples, & frontpage_traces."
     command: psql -c '{{ lookup("file", item) }}'
     with_items: "{{ fpsd_database_raw_schema_tables }}"
-    # Each file is of the form create_table_<table name>.sql, hence the magic
-    # numbers
-    when: "item[13:-4] not in tables.stdout"
+    # Each file is of the form create_table_<table name>.sql, so let's extract the
+    # expected table name and inspect the table list to check if it already exists.
+    when: item|regex_replace('^create_table_(.*)\\.sql$', '\\1') not in tables.stdout
 
   environment: "{{ fpsd_database_psql_env }}"

--- a/roles/database/tasks/initialize-raw-schema.yml
+++ b/roles/database/tasks/initialize-raw-schema.yml
@@ -16,9 +16,9 @@
 
   - name: "Create the tables: crawls, hs_history, frontpage_examples, & frontpage_traces."
     command: psql -c '{{ lookup("file", item) }}'
-    with_items: "{{ raw_schema_tables }}"
+    with_items: "{{ fpsd_database_raw_schema_tables }}"
     # Each file is of the form create_table_<table name>.sql, hence the magic
     # numbers
     when: "item[13:-4] not in tables.stdout"
 
-  environment: "{{ psql_env }}"
+  environment: "{{ fpsd_database_psql_env }}"

--- a/roles/database/tasks/initialize-test-db.yml
+++ b/roles/database/tasks/initialize-test-db.yml
@@ -3,9 +3,9 @@
   become: true
   become_user: postgres
   postgresql_db:
-    name: "test{{ psql_env.PGDATABASE }}"
-    owner: "{{ psql_env.PGUSER }}"
+    name: "test{{ fpsd_database_psql_env.PGDATABASE }}"
+    owner: "{{ fpsd_database_psql_env.PGUSER }}"
     encoding: UTF-8 
     lc_collate: en_US.UTF-8
     lc_ctype: en_US.UTF-8
-    template: "{{ psql_env.PGDATABASE }}"
+    template: "{{ fpsd_database_psql_env.PGDATABASE }}"

--- a/roles/database/tasks/initialize-test-db.yml
+++ b/roles/database/tasks/initialize-test-db.yml
@@ -5,7 +5,7 @@
   postgresql_db:
     name: "test{{ fpsd_database_psql_env.PGDATABASE }}"
     owner: "{{ fpsd_database_psql_env.PGUSER }}"
-    encoding: UTF-8 
+    encoding: UTF-8
     lc_collate: en_US.UTF-8
     lc_ctype: en_US.UTF-8
     template: "{{ fpsd_database_psql_env.PGDATABASE }}"

--- a/roles/database/tasks/install-apt-deps.yml
+++ b/roles/database/tasks/install-apt-deps.yml
@@ -2,7 +2,7 @@
 - name: Install PostgreSQL.
   become: true
   apt:
-    name: "{{ postgresql_apt_packages }}"
+    name: "{{ fpsd_database_apt_packages }}"
     state: latest
     update_cache: yes
     cache_valid_time: 86400

--- a/roles/database/tasks/main.yml
+++ b/roles/database/tasks/main.yml
@@ -1,8 +1,12 @@
 ---
 - include: install-apt-deps.yml
-  when: initialize_local_db
+  when: fpsd_database_initialize_local_db
+
 - include: initialize-fpsd-db.yml
-  when: initialize_local_db
+  when: fpsd_database_initialize_local_db
+
 - include: set-environment-variables.yml
+
 - include: initialize-raw-schema.yml
+
 - include: initialize-test-db.yml

--- a/roles/database/tasks/set-environment-variables.yml
+++ b/roles/database/tasks/set-environment-variables.yml
@@ -1,16 +1,10 @@
 ---
-- name: Test if a PostgreSQL password file is present.
-  stat:
-    path: "{{ fpsd_database_psql_env.PGPASSFILE }}"
-  register: password_file
-  changed_when: false
-  
-- name: Create the PostgreSQL password file for a local database.
+- name: Create the PostgreSQL password file for database connection.
   template:
     src: pgpass_conf.j2
     dest: "{{ fpsd_database_psql_env.PGPASSFILE }}"
     mode: "0600"
-  when: not password_file.stat.exists
+    force: no # Don't clobber preexisting file, since it may contain auth secrets
 
 - name: Set the database environment variables in ~/.bashrc.
   lineinfile:

--- a/roles/database/tasks/set-environment-variables.yml
+++ b/roles/database/tasks/set-environment-variables.yml
@@ -1,14 +1,14 @@
 ---
 - name: Test if a PostgreSQL password file is present.
   stat:
-    path: "{{ psql_env.PGPASSFILE }}"
+    path: "{{ fpsd_database_psql_env.PGPASSFILE }}"
   register: password_file
   changed_when: false
   
 - name: Create the PostgreSQL password file for a local database.
   template:
     src: pgpass_conf.j2
-    dest: "{{ psql_env.PGPASSFILE }}"
+    dest: "{{ fpsd_database_psql_env.PGPASSFILE }}"
     mode: "0600"
   when: not password_file.stat.exists
 
@@ -18,4 +18,4 @@
     regexp: '^export {{ item.key }}='
     dest: "~{{ ansible_user }}/.bashrc"
     mode: "0644"
-  with_dict: "{{ psql_env }}"
+  with_dict: "{{ fpsd_database_psql_env }}"

--- a/roles/database/tasks/set-environment-variables.yml
+++ b/roles/database/tasks/set-environment-variables.yml
@@ -10,6 +10,6 @@
   lineinfile:
     line: 'export {{ item.key }}={{ item.value }}'
     regexp: '^export {{ item.key }}='
-    dest: "~{{ ansible_user }}/.bashrc"
+    dest: "~{{ fpsd_database_username }}/.bashrc"
     mode: "0644"
   with_dict: "{{ fpsd_database_psql_env }}"

--- a/roles/database/templates/pgpass_conf.j2
+++ b/roles/database/templates/pgpass_conf.j2
@@ -1,8 +1,8 @@
 # This file was auto-generated during provisioning of this machine by Ansible
 # using a Jinja2 template
-{% if password %}
-{{ fpsd_database_psql_env.PGHOST }}:{{ fpsd_database_psql_env.PGPORT }}:{{ fpsd_database_psql_env.PGDATABASE }}:{{ fpsd_database_psql_env.PGUSER }}:{{ password }}
-{{ fpsd_database_psql_env.PGHOST }}:{{ fpsd_database_psql_env.PGPORT }}:test{{ fpsd_database_psql_env.PGDATABASE }}:{{ fpsd_database_psql_env.PGUSER }}:{{ password }}
+{% if fpsd_database_password %}
+{{ fpsd_database_psql_env.PGHOST }}:{{ fpsd_database_psql_env.PGPORT }}:{{ fpsd_database_psql_env.PGDATABASE }}:{{ fpsd_database_psql_env.PGUSER }}:{{ fpsd_database_password }}
+{{ fpsd_database_psql_env.PGHOST }}:{{ fpsd_database_psql_env.PGPORT }}:test{{ fpsd_database_psql_env.PGDATABASE }}:{{ fpsd_database_psql_env.PGUSER }}:{{ fpsd_database_password }}
 {% else %}
 {{ fpsd_database_psql_env.PGHOST }}:{{ fpsd_database_psql_env.PGPORT }}:{{ fpsd_database_psql_env.PGDATABASE }}:{{ fpsd_database_psql_env.PGUSER }}:{{ lookup('file', '/tmp/passwordfile') }}
 {{ fpsd_database_psql_env.PGHOST }}:{{ fpsd_database_psql_env.PGPORT }}:test{{ fpsd_database_psql_env.PGDATABASE }}:{{ fpsd_database_psql_env.PGUSER }}:{{ lookup('file', '/tmp/passwordfile') }}

--- a/roles/database/templates/pgpass_conf.j2
+++ b/roles/database/templates/pgpass_conf.j2
@@ -1,9 +1,9 @@
 # This file was auto-generated during provisioning of this machine by Ansible
 # using a Jinja2 template
 {% if fpsd_database_password %}
-{{ fpsd_database_psql_env.PGHOST }}:{{ fpsd_database_psql_env.PGPORT }}:{{ fpsd_database_psql_env.PGDATABASE }}:{{ fpsd_database_psql_env.PGUSER }}:{{ fpsd_database_password }}
-{{ fpsd_database_psql_env.PGHOST }}:{{ fpsd_database_psql_env.PGPORT }}:test{{ fpsd_database_psql_env.PGDATABASE }}:{{ fpsd_database_psql_env.PGUSER }}:{{ fpsd_database_password }}
+{% set _postgres_password=fpsd_database_password %}
 {% else %}
-{{ fpsd_database_psql_env.PGHOST }}:{{ fpsd_database_psql_env.PGPORT }}:{{ fpsd_database_psql_env.PGDATABASE }}:{{ fpsd_database_psql_env.PGUSER }}:{{ lookup('file', '/tmp/passwordfile') }}
-{{ fpsd_database_psql_env.PGHOST }}:{{ fpsd_database_psql_env.PGPORT }}:test{{ fpsd_database_psql_env.PGDATABASE }}:{{ fpsd_database_psql_env.PGUSER }}:{{ lookup('file', '/tmp/passwordfile') }}
+{% set _postgres_password=lookup('file', '/tmp/passwordfile') %}
 {% endif %}
+{{ fpsd_database_psql_env.PGHOST }}:{{ fpsd_database_psql_env.PGPORT }}:{{ fpsd_database_psql_env.PGDATABASE }}:{{ fpsd_database_psql_env.PGUSER }}:{{ _postgres_password }}
+{{ fpsd_database_psql_env.PGHOST }}:{{ fpsd_database_psql_env.PGPORT }}:test{{ fpsd_database_psql_env.PGDATABASE }}:{{ fpsd_database_psql_env.PGUSER }}:{{ _postgres_password }}

--- a/roles/database/templates/pgpass_conf.j2
+++ b/roles/database/templates/pgpass_conf.j2
@@ -1,9 +1,9 @@
 # This file was auto-generated during provisioning of this machine by Ansible
 # using a Jinja2 template
 {% if password %}
-{{ psql_env.PGHOST }}:{{ psql_env.PGPORT }}:{{ psql_env.PGDATABASE }}:{{ psql_env.PGUSER }}:{{ password }}
-{{ psql_env.PGHOST }}:{{ psql_env.PGPORT }}:test{{ psql_env.PGDATABASE }}:{{ psql_env.PGUSER }}:{{ password }}
+{{ fpsd_database_psql_env.PGHOST }}:{{ fpsd_database_psql_env.PGPORT }}:{{ fpsd_database_psql_env.PGDATABASE }}:{{ fpsd_database_psql_env.PGUSER }}:{{ password }}
+{{ fpsd_database_psql_env.PGHOST }}:{{ fpsd_database_psql_env.PGPORT }}:test{{ fpsd_database_psql_env.PGDATABASE }}:{{ fpsd_database_psql_env.PGUSER }}:{{ password }}
 {% else %}
-{{ psql_env.PGHOST }}:{{ psql_env.PGPORT }}:{{ psql_env.PGDATABASE }}:{{ psql_env.PGUSER }}:{{ lookup('file', '/tmp/passwordfile') }}
-{{ psql_env.PGHOST }}:{{ psql_env.PGPORT }}:test{{ psql_env.PGDATABASE }}:{{ psql_env.PGUSER }}:{{ lookup('file', '/tmp/passwordfile') }}
+{{ fpsd_database_psql_env.PGHOST }}:{{ fpsd_database_psql_env.PGPORT }}:{{ fpsd_database_psql_env.PGDATABASE }}:{{ fpsd_database_psql_env.PGUSER }}:{{ lookup('file', '/tmp/passwordfile') }}
+{{ fpsd_database_psql_env.PGHOST }}:{{ fpsd_database_psql_env.PGPORT }}:test{{ fpsd_database_psql_env.PGDATABASE }}:{{ fpsd_database_psql_env.PGUSER }}:{{ lookup('file', '/tmp/passwordfile') }}
 {% endif %}

--- a/vars/database-vars.yml
+++ b/vars/database-vars.yml
@@ -1,16 +1,6 @@
 ---
 ### Used by the database role. ###
 
-# All of these vars except password will be set as environment variables in
-# `/etc/bash.bashrc`. If password is not set, then Ansible will generate one for
-# you at provision-time. The password will not be set as an environment
-# variable, but is instead saved to a PGPASSFILE, `~{{ ssh_username }}/.pgpass`,
-# along with the corresponding information from the other vars according to the
-# PGPASSFILE spec.
-PGHOST: localhost
-PGUSER: fp_user
-PGPORT: "5432"
-PGDATABASE: fpsd
 password: ""
 # Note: the database role will not overwrite an existing PGPASSFILE, so in order
 # to do so, you'll have to first remove it then re-run the role:

--- a/vars/database-vars.yml
+++ b/vars/database-vars.yml
@@ -1,7 +1,1 @@
 ---
-### Used by the database role. ###
-
-password: ""
-# Note: the database role will not overwrite an existing PGPASSFILE, so in order
-# to do so, you'll have to first remove it then re-run the role:
-# `ANSIBLE_ARGS="--tags=database vagrant provision"`.

--- a/vars/database-vars.yml
+++ b/vars/database-vars.yml
@@ -1,14 +1,6 @@
 ---
 ### Used by the database role. ###
 
-# Defaults to true. Set to false if you want to use a remote database. If you
-# wish not to use the database at all, set the environment variable
-# `ANSIBLE_ARGS="--skip-tags=database"`. If set to false you must fill out all
-# vars in the field below so Ansible can still set the appropriate environment
-# variables and create the PGPASSFILE for it just works™ access to your remote
-# database.
-initialize_local_db: true
-
 # All of these vars except password will be set as environment variables in
 # `/etc/bash.bashrc`. If password is not set, then Ansible will generate one for
 # you at provision-time. The password will not be set as an environment


### PR DESCRIPTION
Reorganizes the new database role (merged via #27) to leverage default role vars wherever possible. Removed the top-level vars file for database vars, deferring to sane defaults at the role level. Also added namespacing to all database role vars, to make it clear which vars go where. Retain all explanatory comments throughout the files.

Will comment in-line on a few highlights I'd like further attention on.
