### PR TITLE
Ensure Sorter class_tests order is respected

### DIFF
--- a/fpsd/config.ini
+++ b/fpsd/config.ini
@@ -13,13 +13,12 @@ page_load_timeout = 20
 ; value is, the faster the sorter works, but if set too high, connection errors
 ; may increase significantly.
 max_tasks = 10
-; An ordered dictionary of class names and test functions to be executed.
-; 'text', the HTML body of an onion service page, is the variable of the test
-; function, which should be a boolean expression. The keys are the name of the
-; classes you'd like to create and the values are boolean expressions operating
-; on the 'text' variable. Both keys and values should be strings. Format as:
-; {"<class name>": "<boolean expression>", "<cn>": "<be>", ...}.
-class_tests = {"sd_038": "'Powered by SecureDrop 0.3.8.' in text", "non_monitored": "'SecureDrop' not in text"}
+; The Sorter sorts sites based on user-defined boolean expressions that operate
+; on the HTML body of pages. Create %%-delimited dictionaries, where the key is
+; the class name and the value is some boolean expression that operates on the
+; object reference `text`. Order matters; a site will be sorted into the first
+; class for which the boolean expression evaluates to true.
+class_tests = {"sd_038": "'Powered by SecureDrop 0.3.8.' in text"}%%{"non_monitored": "'SecureDrop' not in text"}
 ; Do you want this data to be inserted into the database?
 use_database = true
 


### PR DESCRIPTION
I mistakenly believe `collections.OrderedDict`, when initialized with multiple
entries, would respect the written order of those entries. Contrarily, it does
not, and in order to preserve that order we need to add on entry at a time.

I chose to use %% as a delimiter simply because I figured it's unlikely to come
up in any boolean expression a user might want to use.

Fixes #33.
