### PR TITLE
Add missing tbselenium dep pyvirtualdisplay to crawler .in

### DIFF
--- a/fpsd/requirements/crawler-requirements.in
+++ b/fpsd/requirements/crawler-requirements.in
@@ -1,3 +1,4 @@
 poyo
+pyvirtualdisplay # for tbselenium.utils.st{art,op}_xvfb
 stem
 tbselenium

--- a/fpsd/requirements/crawler-requirements.txt
+++ b/fpsd/requirements/crawler-requirements.txt
@@ -4,7 +4,9 @@
 #
 #    pip-compile --output-file crawler-requirements.txt crawler-requirements.in
 #
+EasyProcess==0.2.2        # via pyvirtualdisplay
 poyo==0.4.0
+pyvirtualdisplay==0.2
 selenium==2.53.6          # via tbselenium
 stem==1.4.0
 tbselenium==0.1


### PR DESCRIPTION
So the tbselenium devs thought that their tbselenium.utils.st{art,op} functions
would only be used by their own tests. They should have put them under the tests
namespace or made them private or something if they didn't want them to be used.
Anyway, with this in mind they didn't include pyvirtualdisplay in the
`install_requires` field of `setup.py` for building the tbselenium wheel, which
these functions depend on, so we add it ourselves to the top-level crawler
requirements .in file.

Alternatively, we could have added methods to the sorter that would handle this,
but I prefer to opt for DRY on this one.

Note, this bug was introduced in 1a33a7430e9881ae67f2a2025a59fdd1457fe41d, and
would have been caught had I ran our unit tests. It's a real time-suck to
rebuild a VM and re-run all tests for small changes (probably could have cut
some corners on this one, but making a general point here), so I didn't. Had we
had Travis CI running at this point and done a proper (however brief) review of
the PR and CI status checks, we would have caught this before merging into
master w/o much extra work versus just pushing to master (certainly an order of
magnitude less than manual box rebuilding and test suite running).
