### PR TITLE
Install python debugging tools during provisioning

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -7,6 +7,12 @@ common_apt_packages:
   - vim
   - libpq-dev # needed to install psycopg2 
 
+common_pypi_packages:
+  - pip
+  - pytest
+  - ipython
+  - ipdb
+
 ssh_username: "{{ ansible_ssh_user }}"
 
 crawler_project_directory: "~{{ ssh_username }}/FingerprintSecureDrop"

--- a/roles/common/tasks/install-upgrade-pypi.yml
+++ b/roles/common/tasks/install-upgrade-pypi.yml
@@ -1,0 +1,8 @@
+---
+- name: Install and upgrade Python packaging and debugging tools.
+  become: true
+  pip:
+    executable: pip3
+    name: "{{ item }}"
+    state: latest
+  with_items: "{{ common_pypi_packages }}"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
 - include: install-upgrade-apt.yml
+- include: install-upgrade-pypi.yml
 - include: clone-git-repo.yml
 - include: extra-config.yml


### PR DESCRIPTION
Resolves #35.

Also, should fix the current problems regarding pip 8.1.1's inability to install the latest aiohttp package as root (8.1.2 seems to install it fine as root).
