### PR TITLE
Use apt_repository, not lineinfile, to handle apt sources

### DIFF
--- a/roles/crawler/tasks/install-apt-deps.yml
+++ b/roles/crawler/tasks/install-apt-deps.yml
@@ -8,10 +8,10 @@
 
 - name: Download universe sources for tor.
   become: yes
-  lineinfile:
-    dest: /etc/apt/sources.list
-    line: "deb-src http://us.archive.ubuntu.com/ubuntu/ xenial universe"
-    regexp: "# deb-src http://us.archive.ubuntu.com/ubuntu/ xenial universe"
+  apt_repository:
+    filename: "xenial-universe-sources"
+    repo: "deb-src http://us.archive.ubuntu.com/ubuntu/ xenial universe"
+    mode: "0644"
 
 - name: Install Tor build dependencies.
   become: yes


### PR DESCRIPTION
@conorsch discussed this was a better approach than modifying the regex, which after the first provision would add another copy of the line to the `sources.list` file.
