### PR TITLE
Updates the logic to infer a username for configuring dotfiles

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -13,7 +13,7 @@ common_pypi_packages:
   - ipython
   - ipdb
 
-ssh_username: "{{ ansible_ssh_user }}"
+ssh_username: "{{ ansible_user|default(ansible_ssh_user|default(lookup('env', 'USER'))) }}"
 
 crawler_project_directory: "~{{ ssh_username }}/FingerprintSecureDrop"
 crawler_git_repo: "https://github.com/freedomofpress/FingerprintSecureDrop"

--- a/roles/crawler/defaults/main.yml
+++ b/roles/crawler/defaults/main.yml
@@ -17,4 +17,4 @@ tbb_arch: 64
 # Specify Tor version to download, patch, build, and install
 tor_release: 0.2.8.7
 
-ssh_username: "{{ ansible_ssh_user }}"
+ssh_username: "{{ ansible_user|default(ansible_ssh_user|default(lookup('env', 'USER'))) }}"

--- a/roles/database/defaults/main.yml
+++ b/roles/database/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Username to configure postgres access for.
-fpsd_database_username: "{{ ansible_user|default(lookup('env', 'USER')) }}"
+fpsd_database_username: "{{ ansible_user|default(ansible_ssh_user|default(lookup('env', 'USER'))) }}"
 
 fpsd_database_apt_packages:
   - postgresql

--- a/roles/sorter/defaults/main.yml
+++ b/roles/sorter/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-ssh_username: "{{ ansible_ssh_user }}"
+ssh_username: "{{ ansible_user|default(ansible_ssh_user|default(lookup('env', 'USER'))) }}"


### PR DESCRIPTION
We can't assume that `ansible_ssh_user` will be defined, since it's not
populated by default in Ansible. When provisioning Vagrant VMs, the
`ansible_ssh_user` var is defined because it's hardcoded in the static
inventory file that Vagrant generates.

Let's prefer `ansible_user`, which supersedes `ansible_ssh_user` as of v2,
but still honor `ansible_ssh_user` to support Vagrant. If neither can be
found, we'll fall back to using the username of the account running
ansible on the Ansible controller.
