### PR TITLE
Fix Crawler breakage caused by mis-configured Tor

### DIFF
--- a/fpsd/config.ini
+++ b/fpsd/config.ini
@@ -5,8 +5,8 @@
 ; of sites than SecureDrop.
 
 [sorter]
-; Space delimited list of hidden service directories
-onion_dirs = http://secrdrop5wyphb5x.onion/sites/securedrop.org/files/securedrop_list.txt http://msydqstlz2kzerdg.onion/address/ http://skunksworkedp2cg.onion/sites.html
+; Comma-delimited list of hidden service directories
+onion_dirs = http://secrdrop5wyphb5x.onion/sites/securedrop.org/files/securedrop_list.txt,http://msydqstlz2kzerdg.onion/address/,http://skunksworkedp2cg.onion/sites.html
 ; Time to wait for a onion service to load before timing out
 page_load_timeout = 20
 ; Number of asynchronous connections to have open at a time. The higher this
@@ -47,6 +47,6 @@ restart_on_sketchy_exception = True
 ; Traces to record of each monitored site for every trace of a non-monitored
 ; site
 monitored_nonmonitored_ratio = 10
-; Space-delimited list of preferred EntryNodes. Tor will make the first
+; Comma-delimited list of preferred EntryNodes. Tor will make the first
 ; sequentially listed one reachable the client guard.
-entry_nodes = 1B60184DB9B96EA500A19C52D88F145BA5EC93CD 9571563903DF1DE2A3CE84973AF94F485D13FAD4 557B96445746BAE5FF9181D95E629B4CF0C23CB5
+entry_nodes = 1B60184DB9B96EA500A19C52D88F145BA5EC93CD,9571563903DF1DE2A3CE84973AF94F485D13FAD4,557B96445746BAE5FF9181D95E629B4CF0C23CB5

--- a/fpsd/crawler.py
+++ b/fpsd/crawler.py
@@ -513,8 +513,8 @@ def _securedrop_crawl():
                  wait_after_closing_circuits=config.getint("wait_after_closing_circuits"),
                  restart_on_sketchy_exception=config.getboolean("restart_on_sketchy_exception"),
                  db_handler=fpdb,
-                 torrc_config={"CookieAuth": "1",
-                               "EntryNodes": config["entry_nodes"].split()}) as crawler:
+                 torrc_config={"CookieAuthentication": "1",
+                               "EntryNodes": config["entry_nodes"]}) as crawler:
         crawler.crawl_monitored_nonmonitored(monitored_class,
                                              nonmonitored_class,
                                              monitored_name=monitored_name,

--- a/fpsd/crawler.py
+++ b/fpsd/crawler.py
@@ -60,6 +60,7 @@ class Crawler:
     def __init__(self, 
                  take_ownership=True, # Tor dies when the Crawler does
                  torrc_config={"CookieAuth": "1"},
+                 tor_log=join(_log_dir, "tor.log"),
                  tor_cell_log=join(_log_dir,"tor_cell_seq.log"),
                  control_port=9051,
                  socks_port=9050, 
@@ -81,6 +82,7 @@ class Crawler:
         self.torrc_config.update({"SocksPort": str(self.socks_port)})
         self.control_port = find_free_port(control_port, self.socks_port)
         self.torrc_config.update({"ControlPort": str(self.control_port)})
+        self.torrc_config.update({"Log": "DEBUG file {}".format(tor_log)})
         self.logger.info("Starting tor process with config "
                          "{torrc_config}.".format(**locals()))
         self.tor_process = launch_tor_with_config(config=self.torrc_config,

--- a/fpsd/crawler.py
+++ b/fpsd/crawler.py
@@ -452,7 +452,7 @@ class Crawler:
             if not url_to_id_mapping:
                 url_to_id_mapping = nonmonitored_class
                 url_to_id_mapping.update(monitored_class)
-            trace_dir, mon_trace_dir, non_mon_trace_dir = (None,) * 3
+            trace_dir, mon_trace_dir, nonmon_trace_dir = (None,) * 3
         else:
             trace_dir = self.make_ts_dir()
             mon_trace_dir = join(trace_dir, monitored_name)

--- a/fpsd/sorter.py
+++ b/fpsd/sorter.py
@@ -107,21 +107,24 @@ class Sorter:
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.close()
-        return self
 
 
     def __del__(self):
         self.close()
-        return self
 
 
     def close(self):
-        self.logger.info("Closing out any lingering HTTP connections...")
-        self.session.close()
-        self.logger.info("Closing event loop...")
-        self.loop.close()
-        self.logger.info("Killing the Tor process...")
-        self.tor_process.kill()
+        self.logger.info("Beginning the Sorter exit process..."
+        if "session" in dir(self):
+            self.logger.info("Closing out any lingering HTTP connections...")
+            self.session.close()
+        if loop in dir(self):
+            self.logger.info("Closing the event loop...")
+            self.loop.close()
+        if "tor_process" in dir(self):
+            self.logger.info("Killing the Tor process...")
+            self.tor_process.kill()
+        self.logger.info("Sorter exit complete.")
 
 
     def scrape_directories(self, onion_dirs):

--- a/fpsd/sorter.py
+++ b/fpsd/sorter.py
@@ -341,7 +341,7 @@ def _securedrop_sort():
     with Sorter(page_load_timeout=config.getint("page_load_timeout"),
                 max_tasks=config.getint("max_tasks"),
                 db_handler=fpdb) as sorter:
-        sorter.scrape_directories(config["onion_dirs"].split())
+        sorter.scrape_directories(config["onion_dirs"].split(","))
         sorter.sort_onions(class_tests)
 
 


### PR DESCRIPTION
That #54 was not rebased on #66, which introduced a bug fixed in fbeb9d7. Mis-configuration of Tor via #66 caused the Firefox binary to crash leaving no Python traceback to help us figure out what was going on. Tor Browser Bundle (specifically TorButton) doesn't provide the best output for debugging, but after finding https://github.com/webfp/tor-browser-selenium/issues/62, I decided to set the Tor log to debug and take a close look. Tor was bootstrapping correctly, but it was still mis-configured, and that was causing TBB to crash.

I couldn't find anything in the selenium FF webdriver code that would allow me to get more debug info from TBB, but I probably should have looked to the documentation because selenium is very large, and it's probably just in another module. It's solved, anyway.
