### PR TITLE
Simplifies group membership update task

### DIFF
--- a/roles/crawler/tasks/configure.yml
+++ b/roles/crawler/tasks/configure.yml
@@ -11,24 +11,12 @@
       name: "{{ fpsd_crawler_system_account }}"
       system: yes
 
-  # Necessary because the user module is not idempotent.
-  - name: List what groups each user is in.
-    command: "groups {{ item }}"
-    with_items: "{{ fpsd_crawler_system_account }}"
-    register: groups_result
-    always_run: true
-    changed_when: false
-
   - name: Add users to system group for running crawler.
     user:
       append: yes
       groups: "{{ fpsd_crawler_system_account }}"
-      name: "{{ item.1 }}"
-    when: "fpsd_crawler_system_account not in item.0.stdout"
-    with_together: 
-      - "{{ groups_result.results }}"
-      - "{{ fpsd_database_usernames }}"
-    failed_when: true
+      name: "{{ item }}"
+    with_items: "{{ fpsd_database_usernames }}"
 
   - name: Create project directory.
     file:


### PR DESCRIPTION
The original intent here is to add all authorized users to the `fpsd`
group so that developers can run commands as the `fpsd` service account
without directly su'ing as the service account user. Makes sense.

The previous implementation was using a two-pass approach to accommodate
for improper idempotence handling in Ansible's `user` module. Was able
to reproduce the issue reliably on Ansible v2.1.1, but Ansible v2.2.0
has resolved the issue, and the role applies cleanly on multiple runs
with the new one-task approach.