### PR TITLE
Fixes for crawler and sorter

### DIFF
--- a/fpsd/attack.py
+++ b/fpsd/attack.py
@@ -20,7 +20,7 @@ def run(options):
     with open(options, 'r') as f:
         options = yaml.load(f)
 
-    db = database.DatasetLoader(test=False)
+    db = database.DatasetLoader()
 
     df = db.load_world(options["world"]["type"])
 

--- a/fpsd/classify.py
+++ b/fpsd/classify.py
@@ -47,7 +47,7 @@ class Experiment:
         self.n_cores = n_cores
         self.k = k
         self.feature_scaling = feature_scaling
-        self.db = database.ModelStorage(test=False)
+        self.db = database.ModelStorage()
         self.train_class_balance = 'DEFAULT'
         self.base_rate = 'DEFAULT'
 

--- a/fpsd/config.ini
+++ b/fpsd/config.ini
@@ -6,9 +6,7 @@
 
 [sorter]
 ; Comma-delimited list of hidden service directories
-onion_dirs = http://secrdrop5wyphb5x.onion/sites/securedrop.org/files/securedrop_list.txt
-  http://msydqstlz2kzerdg.onion/address/
-  http://skunksworkedp2cg.onion/sites.html
+onion_dirs = http://secrdrop5wyphb5x.onion/sites/securedrop.org/files/securedrop_list.txt,http://msydqstlz2kzerdg.onion/address/,http://skunksworkedp2cg.onion/sites.html
 ; Time to wait for a onion service to load before timing out
 page_load_timeout = 20
 ; Number of asynchronous connections to have open at a time. The higher this

--- a/fpsd/config.ini
+++ b/fpsd/config.ini
@@ -51,21 +51,3 @@ monitored_nonmonitored_ratio = 10
 ; List of preferred EntryNodes. Tor will make the first
 ; sequentially listed one reachable the client guard.
 entry_nodes = 237C733E2D1BAD26FAABEAFB612BDA0CD3BC6AF4,95CDFAA852FF075FCD23102C06636F2B84B3371A,E727D0B4179549BB3F82ED3C256F209E54CE0B23,41E2FB97690EED79DD4BD6BAC00A974B69F49858
-
-[database]
-; The username to authenticate to your production database. Password should be
-; in a PGPASSFILE (normally generated for you by Ansible).
-pguser = fp_user
-; The IP of your database
-pghost = localhost
-; The port on which to connect to your production database>
-pgport = 5432
-; Your production database name.
-pgdatabase = fpsd
-
-[test_database]
-; Only necessary if you wish to run the tests.
-pguser = fp_user
-pghost = localhost
-pgport = 5432
-pgdatabase = testfpsd

--- a/fpsd/database.py
+++ b/fpsd/database.py
@@ -11,7 +11,7 @@ from sqlalchemy.engine.url import URL as SQL_connect_URL
 from sqlalchemy.ext.automap import automap_base
 from sqlalchemy.orm import Session
 
-from utils import get_config, get_lookback, get_timestamp, panic
+from utils import get_config, get_db_creds, get_lookback, get_timestamp, panic
 
 
 class Database:
@@ -22,36 +22,25 @@ class Database:
                                  database engine configuration. Contains
                                  the following keys: 'pguser', 'pghost',
                                  'pgport', & 'pgdatabase'. If not passed
-                                 values will read from the [database]
-                                 section of './config.ini'.
-    :param bool test: An optional parameter specifiying if the test or
-                      production database should be used. Defaults to
-                      true (to use thetest database).
+                                 values then it will read from the
+                                 PGPASSFILE that stores the password.
 
     :raises: An :exc:OperationalError, when unable to initialize the
              database engine with the given database configuration.
     """
-    def __init__(self, database_config=None, test=True):
+    def __init__(self, database_config=None):
         if not database_config:
-            config = get_config()
-            if test:
-                database_config = dict(config.items("test_database"))
-            else:
-                database_config = dict(config.items("database"))
+            try:
+                database_config = get_db_creds()
+            except OperationalError as exc:
+                panic("fingerprint-securedrop Postgres support relies on use of a "
+                      "PGPASSFILE. Make sure this file and the env var pointing "
+                      "to it exist and set 0600 permissions & user ownership."
+                      "\n{}.".format(exc))
 
-        try:
-            with open(os.environ["PGPASSFILE"], "rb") as f:
-                content = f.read().decode("utf-8").replace("\n", "").split(":")
-                database_config["pgpass"] = content[-1]
-
-            self.engine = create_engine(
-                'postgresql://{pguser}:{pgpass}@{pghost}:{pgport}/{pgdatabase}'.format(
+        self.engine = create_engine(
+                'postgresql://{pguser}:@{pghost}:{pgport}/{pgdatabase}'.format(
                     **database_config))
-        except OperationalError as exc:
-            panic("fingerprint-securedrop Postgres support relies on use of a "
-                  "PGPASSFILE. Make sure this file and the env var pointing "
-                  "to it exist and set 0600 permissions & user ownership."
-                  "\n{}.".format(exc))
 
 
     @contextmanager

--- a/fpsd/database.py
+++ b/fpsd/database.py
@@ -34,8 +34,9 @@ class Database:
                 database_config = get_db_creds()
             except OperationalError as exc:
                 panic("fingerprint-securedrop Postgres support relies on use of a "
-                      "PGPASSFILE. Make sure this file and the env var pointing "
-                      "to it exist and set 0600 permissions & user ownership."
+                      "PGPASSFILE. Make sure this file exists in your homedir "
+                      "with the first entry corresponding to the database you "
+                      "wish to use. Also set 0600 permissions & user ownership."
                       "\n{}.".format(exc))
 
         self.engine = create_engine(

--- a/fpsd/features.py
+++ b/fpsd/features.py
@@ -731,7 +731,7 @@ class FeatureStorage(Database):
 
 
 def compute_wang_feature_set():
-    db = FeatureStorage(test=False)
+    db = FeatureStorage()
 
     # Create master table to store list of examples that we have generated features for
     db.create_table_undefended_frontpage_links()

--- a/fpsd/tests/common.py
+++ b/fpsd/tests/common.py
@@ -1,12 +1,13 @@
 from configparser import ConfigParser
 
 from database import Database
-from utils import get_config
+from utils import get_db_creds
 
 class TestDatabase(Database):
     """A mixin class that fetches the values for the test database from
     the configuration file."""
     def __init__(self, **kwargs):
-        config = get_config()
-        test_db_config = dict(config.items("test_database"))
+        test_db_config = get_db_creds()
+        test_db_config["pghost"] = "localhost"
+        test_db_config["pgdatabase"] = "testfpsd"
         super().__init__(test_db_config)

--- a/fpsd/tests/test_utils.py
+++ b/fpsd/tests/test_utils.py
@@ -9,8 +9,6 @@ class ConfigParsingTest(unittest.TestCase):
         config = get_config()
         self.assertTrue(config.has_section('sorter'))
         self.assertTrue(config.has_section('crawler'))
-        self.assertTrue(config.has_section('database'))
-        self.assertTrue(config.has_section('test_database'))
         self.assertIsInstance(config.getint('sorter', 'page_load_timeout'),
                               int)
         entry_nodes = config['crawler']['entry_nodes'].split(',')

--- a/fpsd/utils.py
+++ b/fpsd/utils.py
@@ -12,6 +12,26 @@ import sys
 _dir = dirname(abspath(__file__))
 
 
+def get_db_creds():
+    """Reads the db credentials from the PGPASSFILE that should exist
+    in the homedir with format pghost:pgport:pgdatabase:pguser:pgpasswd
+    """
+
+    database_config = {}
+    with open(os.path.expanduser("~/.pgpass"), "rb") as f:
+        content = f.read().decode("utf-8").split("\n")
+    for line in content:
+        if not line.strip().startswith("#"):
+            creds = line.split(':')
+            database_config["pghost"] = creds[0]
+            database_config["pgport"] = creds[1]
+            database_config["pgdatabase"] = creds[2]
+            database_config["pguser"] = creds[3]
+
+            # Use first entry
+            return database_config
+
+
 def get_config():
     """Return an :obj:config.ConfigParser that has parse the file
     "./config.ini."


### PR DESCRIPTION
Fix a couple of issues with the sorter and crawler:

1. It looks like the reason the sorter was immediately exiting is that in 0a6b52538d121e58982c68b7042f90b526e8dd53 the delimiter between directories in config.ini was changed to `\n` but the delimiter the sorter was expecting is `,` so it was no longer parsing any directory URLs. 
2. `config.ini` was not being populated with the prod db values since Ansible was not setting up `config.ini`. Made a minor change to read from `~/.pgpass` (since Ansible is setting that up on the dev VM and the VPSes). This also closes #93 and closes #94 