### PR TITLE
Convert config.ini to a Jinja2 template

### DIFF
--- a/fpsd/.gitignore
+++ b/fpsd/.gitignore
@@ -1,0 +1,1 @@
+config.ini

--- a/fpsd/crawler.py
+++ b/fpsd/crawler.py
@@ -497,8 +497,7 @@ class Crawler:
                                        trace_dir=nonmon_trace_dir)
 
 def _securedrop_crawl():
-    config = get_config()
-    config = config["crawler"]
+    config = get_config()['crawler']
     if config.getboolean("use_database"):
         fpdb = RawStorage()
         class_data = fpdb.get_onions(config["hs_history_lookback"])

--- a/fpsd/sorter.py
+++ b/fpsd/sorter.py
@@ -329,8 +329,7 @@ class Sorter:
 
 
 def _securedrop_sort():
-    config = get_config()
-    config = config["sorter"]
+    config = get_config()['sorter']
     if config.getboolean("use_database"):
         fpdb = RawStorage()
     else:

--- a/fpsd/tests/common.py
+++ b/fpsd/tests/common.py
@@ -1,13 +1,14 @@
 from configparser import ConfigParser
 
 from database import Database
-from utils import get_db_creds
 
 class TestDatabase(Database):
     """A mixin class that fetches the values for the test database from
     the configuration file."""
     def __init__(self, **kwargs):
-        test_db_config = get_db_creds()
+        test_db_config = dict()
         test_db_config["pghost"] = "localhost"
         test_db_config["pgdatabase"] = "testfpsd"
+        test_db_config["pguser"] = "fp_user"
+        test_db_config["pgport"] = 5432
         super().__init__(test_db_config)

--- a/fpsd/utils.py
+++ b/fpsd/utils.py
@@ -11,27 +11,6 @@ import sys
 
 _dir = dirname(abspath(__file__))
 
-
-def get_db_creds():
-    """Reads the db credentials from the PGPASSFILE that should exist
-    in the homedir with format pghost:pgport:pgdatabase:pguser:pgpasswd
-    """
-
-    database_config = {}
-    with open(os.path.expanduser("~/.pgpass"), "rb") as f:
-        content = f.read().decode("utf-8").split("\n")
-    for line in content:
-        if not line.strip().startswith("#"):
-            creds = line.split(':')
-            database_config["pghost"] = creds[0]
-            database_config["pgport"] = creds[1]
-            database_config["pgdatabase"] = creds[2]
-            database_config["pguser"] = creds[3]
-
-            # Use first entry
-            return database_config
-
-
 def get_config():
     """Return an :obj:config.ConfigParser that has parse the file
     "./config.ini."

--- a/roles/crawler/defaults/main.yml
+++ b/roles/crawler/defaults/main.yml
@@ -56,6 +56,20 @@ fpsd_database_apt_packages:
   - libpq-dev
   - python-psycopg2
 
+# List of hidden service directories to sort
+fpsd_onion_dirs:
+  - http://secrdrop5wyphb5x.onion/sites/securedrop.org/files/securedrop_list.txt
+  - http://msydqstlz2kzerdg.onion/address/
+  - http://skunksworkedp2cg.onion/sites.html
+
+# List of preferred EntryNodes. Tor will make the first sequentially listed one
+# reachable the client guard.
+fpsd_entry_nodes: 
+  - 237C733E2D1BAD26FAABEAFB612BDA0CD3BC6AF4
+  - 95CDFAA852FF075FCD23102C06636F2B84B3371A
+  - E727D0B4179549BB3F82ED3C256F209E54CE0B23
+  - 41E2FB97690EED79DD4BD6BAC00A974B69F49858
+
 # If left undefined, a randomly generated password will be created and written
 # to /tmp on the Ansible controller.
 fpsd_database_password: "{{ lookup('password', '/tmp/passwordfile chars=ascii_letters,digits') }}"
@@ -76,7 +90,6 @@ fpsd_database_psql_env:
   PGPORT: "5432"
   PGDATABASE: fpsd
   PGPASSWORD: "{{ fpsd_database_password }}"
-  PGPASSFILE: "{{ ansible_env.HOME }}/.pgpass"
 
 # Defaults to true. Set to false if you want to use a remote database. If you
 # wish not to use the database at all, set the environment variable

--- a/roles/crawler/tasks/configure.yml
+++ b/roles/crawler/tasks/configure.yml
@@ -38,6 +38,12 @@
     # to pull, so check the boolean var for toggling cloning functionality.
     when: fpsd_crawler_clone_git_repo == true
 
+  - name: Populate config.ini.
+    template:
+      src: config.ini.j2
+      dest: "{{ fpsd_crawler_project_directory }}/fpsd/config.ini"
+      force: no
+
   - name: Install crawler pip dependencies.
     pip:
       executable: pip3

--- a/roles/crawler/tasks/set-environment-variables.yml
+++ b/roles/crawler/tasks/set-environment-variables.yml
@@ -12,10 +12,7 @@
 - name: Set the database environment variables in global bashrc.
   become: yes
   lineinfile:
-    # Overriding the value for PGPASS to use `$HOME` so it's generalized for all users.
-    # The previous task wrote the pgpass file to each user's HOME, which is mandatory
-    # because postgres wants the PGPASS file to be mode 600, so it can't be shared.
-    line: 'export {{ item.key }}={{ "$HOME/.pgpass" if item.key == "PGPASSFILE" else item.value }}'
+    line: 'export {{ item.key }}={{ item.value }}'
     regexp: '^export {{ item.key }}='
     dest: "/etc/bash.bashrc"
     mode: "0644"

--- a/roles/crawler/templates/config.ini.j2
+++ b/roles/crawler/templates/config.ini.j2
@@ -6,7 +6,7 @@
 
 [sorter]
 ; Comma-delimited list of hidden service directories
-onion_dirs = http://secrdrop5wyphb5x.onion/sites/securedrop.org/files/securedrop_list.txt,http://msydqstlz2kzerdg.onion/address/,http://skunksworkedp2cg.onion/sites.html
+onion_dirs = {{ fpsd_onion_dirs|join(',') }}
 ; Time to wait for a onion service to load before timing out
 page_load_timeout = 20
 ; Number of asynchronous connections to have open at a time. The higher this
@@ -50,4 +50,15 @@ restart_on_sketchy_exception = True
 monitored_nonmonitored_ratio = 10
 ; List of preferred EntryNodes. Tor will make the first
 ; sequentially listed one reachable the client guard.
-entry_nodes = 237C733E2D1BAD26FAABEAFB612BDA0CD3BC6AF4,95CDFAA852FF075FCD23102C06636F2B84B3371A,E727D0B4179549BB3F82ED3C256F209E54CE0B23,41E2FB97690EED79DD4BD6BAC00A974B69F49858
+entry_nodes = {{ fpsd_entry_nodes|join(',') }}
+
+[database]
+; The username to authenticate to your production database. Password should be
+; in a PGPASSFILE (normally generated for you by Ansible).
+pguser = {{ fpsd_database_psql_env.PGUSER }}
+; The IP of your database
+pghost = {{ fpsd_database_psql_env.PGHOST }}
+; The port on which to connect to your production database>
+pgport = {{ fpsd_database_psql_env.PGPORT }}
+; Your production database name.
+pgdatabase = {{ fpsd_database_psql_env.PGDATABASE }}


### PR DESCRIPTION
* Moves `fpsd/config.ini` to a template under `roles/crawler/templates/config.ini.j2`.
* If a `fpsd/config.ini` file is not already present on a remote machine, the template will be rendered using default vars (which can be overridden by play-level vars). The template will not be clobbered in order to prevent re-provisioning from overwriting custom config tweaks (not all fields in the config file are filled by Ansible vars).
* All test database values are hard-coded into the `TestDatabase` mixin class.
* The `PGPASSFILE` env var is no longer set because we put it in the default location, `~/.pgpass`, where no env var is needed to find it.